### PR TITLE
Repopulate program.sentRegistrationEmailAddresses when reclassification ...

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -396,7 +396,9 @@ app.post('/programs/:id/reclassification', function(req, res, next) {
     if (err) next(err)
     if (!classificationUtils.canReclassify(program, req.user)) return res.send(400)
     program.newDraftClassification(req.user)
-    program.save(respond(res, next))
+    program.populateSentRegistrationEmailAddresses([], function(err) {
+      program.save(respond(res, next))
+    })
   })
 })
 


### PR DESCRIPTION
...begins

If buyer or author email addresses have changed, this shows the correct new addresses in the UI when reclassifying.

Also, since programs coming in from the XML api don't have sentRegistrationEmailAddresses populated, this fills buyer + author emails for those as well.

Repopulating sentRegistrationEmailAddresses on register is still necessary to add the authors own email address to the array. (Could be simpler tho)
