### PR TITLE
[update] IKLU-49: change email domains from kavi to kuvi.

### DIFF
--- a/server/provider-utils.js
+++ b/server/provider-utils.js
@@ -177,7 +177,7 @@ exports.payingLocationsWithoutEmail = function (locations) {
 function providerEmail(fields) {
   return {
     recipients: ['tarjoajarekisteri@kuvi.fi'].concat(fields.recipients),
-    from: 'tarjoajarekisteri@kavi.fi',
+    from: 'tarjoajarekisteri@kuvi.fi',
     subject: fields.subject,
     body: fields.body
   }

--- a/shared/classification-utils.js
+++ b/shared/classification-utils.js
@@ -102,7 +102,7 @@
     const svData = generateData('sv')
     return {
       recipients: _.uniq(program.sentRegistrationEmailAddresses.concat(utils.hasRole(user, 'root') ? [] : user.email)),
-      from: 'kirjaamo@kavi.fi',
+      from: 'kirjaamo@kuvi.fi',
       subject: _.template('Luokittelupäätös: <%= name %><%= programType %>, <%- year %>, <%- classificationShort %>')(fiData),
       body: '<div style="text-align: right; margin-top: 8px;"><!-- <img src="' + hostName + '/images/logo.png" />-->' +
           'TAIDE- JA KULTTUURIVIRASTO<br>' +


### PR DESCRIPTION
DNS records required by SendGrid have been created by Valtori, so sending mail from the application as `kuvi.fi` should work now.